### PR TITLE
Allow JaCoCo to ignore package prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 JaCoCo Java Code Coverage Library
 =================================
 
+# This is a JaCoCo fork to allow package prefixes to be ignored when finding source files
+
+It will produce unexpected results if attempting to generate reports across multiple packages.
+
+See [this comment](https://github.com/jacoco/jacoco/pull/953#issuecomment-540843609) for more details
+
 [![Build Status](https://dev.azure.com/jacoco-org/JaCoCo/_apis/build/status/JaCoCo?branchName=master)](https://dev.azure.com/jacoco-org/JaCoCo/_build/latest?definitionId=1&branchName=master)
 [![Maven Central](https://img.shields.io/maven-central/v/org.jacoco/jacoco.svg)](http://search.maven.org/#search|ga|1|g%3Aorg.jacoco)
 

--- a/org.jacoco.report/src/org/jacoco/report/InputStreamSourceFileLocator.java
+++ b/org.jacoco.report/src/org/jacoco/report/InputStreamSourceFileLocator.java
@@ -46,7 +46,7 @@ public abstract class InputStreamSourceFileLocator
 
 	public Reader getSourceFile(final String packageName, final String fileName)
 			throws IOException {
-		final InputStream in = findSourceStream(packageName.split("/"),
+		final InputStream in = getSourceStream(packageName.split("/"),
 				fileName);
 
 		if (in == null) {
@@ -60,7 +60,7 @@ public abstract class InputStreamSourceFileLocator
 		}
 	}
 
-	private InputStream findSourceStream(String[] packageName, String fileName)
+	private InputStream getSourceStream(String[] packageName, String fileName)
 			throws IOException {
 		for (int i = 0; i < packageName.length; i++) {
 			final String location = String.join("/",

--- a/org.jacoco.report/src/org/jacoco/report/InputStreamSourceFileLocator.java
+++ b/org.jacoco.report/src/org/jacoco/report/InputStreamSourceFileLocator.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.util.*;
 
 /**
  * Abstract base class for {@link ISourceFileLocator} locator implementations
@@ -45,12 +46,8 @@ public abstract class InputStreamSourceFileLocator
 
 	public Reader getSourceFile(final String packageName, final String fileName)
 			throws IOException {
-		final InputStream in;
-		if (packageName.length() > 0) {
-			in = getSourceStream(packageName + "/" + fileName);
-		} else {
-			in = getSourceStream(fileName);
-		}
+		final InputStream in = findSourceStream(packageName.split("/"),
+				fileName);
 
 		if (in == null) {
 			return null;
@@ -61,6 +58,19 @@ public abstract class InputStreamSourceFileLocator
 		} else {
 			return new InputStreamReader(in, encoding);
 		}
+	}
+
+	private InputStream findSourceStream(String[] packageName, String fileName)
+			throws IOException {
+		for (int i = 0; i < packageName.length; i++) {
+			final String location = String.join("/",
+					Arrays.copyOfRange(packageName, i, packageName.length));
+			final InputStream in = getSourceStream(location + "/" + fileName);
+			if (in != null) {
+				return in;
+			}
+		}
+		return getSourceStream(fileName);
 	}
 
 	public int getTabWidth() {


### PR DESCRIPTION
We modify the `InputSourceFileLocator` to drop package prefixes when searching for source files.

For example, when searching for `com.foo.bar.Example` it will search for not only `com/foo/bar/Example.kt` but also `foo/bar/Example.kt`, `bar/Example.kt`, `Example.kt`

See https://github.com/jacoco/jacoco/pull/953 for a similar PR on main JaCoCo, with a note on the issue this can cause when dealing with multiple modules at once.